### PR TITLE
Vistas comparar radares Fase 2

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { CompareRadarsComponent } from './compare-radars/compare-radars.componen
 import { AxisBarChartComponent } from './chart-components/axis-bar-chart/axis-bar-chart.component';
 import { AxisTableValuesComponent } from './chart-components/axis-table-values/axis-table-values.component';
 import { RadarChartComponent } from './chart-components/radar-chart/radar-chart.component';
+import { CompareRadarsButtonsComponent } from './compare-radars/compare-radars-buttons/compare-radars-buttons.component';
 
 @NgModule({
   declarations: [
@@ -43,7 +44,8 @@ import { RadarChartComponent } from './chart-components/radar-chart/radar-chart.
     RadarFormComponent,
     AxesFormComponent,
     SelectToCompareComponent,
-    CompareRadarsComponent
+    CompareRadarsComponent,
+    CompareRadarsButtonsComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/compare-radars/compare-radars-buttons/compare-radars-buttons.component.html
+++ b/src/app/compare-radars/compare-radars-buttons/compare-radars-buttons.component.html
@@ -1,0 +1,17 @@
+<div class="back-to-buttons">
+  <button
+    type="button"
+    class="btn btn-secondary back-to-index-button"
+    (click)="backToIndex()"
+  >
+    Volver al index
+  </button>
+
+  <button
+    type="button"
+    class="btn btn-success back-to-stc-button"
+    (click)="backToSelectToCompare()"
+  >
+    Volver a seleccionar
+  </button>
+</div>

--- a/src/app/compare-radars/compare-radars-buttons/compare-radars-buttons.component.scss
+++ b/src/app/compare-radars/compare-radars-buttons/compare-radars-buttons.component.scss
@@ -1,0 +1,13 @@
+.back-to-buttons {
+    display: flex;
+    justify-content: center;
+    margin: 1.5em;
+}
+
+.back-to-index-button {
+    margin-right: 0.5em;
+}
+
+.back-to-stc-button {
+    margin-left: 0.5em;
+}

--- a/src/app/compare-radars/compare-radars-buttons/compare-radars-buttons.component.ts
+++ b/src/app/compare-radars/compare-radars-buttons/compare-radars-buttons.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-compare-radars-buttons',
+  templateUrl: './compare-radars-buttons.component.html',
+  styleUrls: ['./compare-radars-buttons.component.scss']
+})
+export class CompareRadarsButtonsComponent implements OnInit {
+
+  constructor(private router: Router) { }
+
+  ngOnInit() { }
+
+  backToIndex() {
+    this.router.navigate(['/radars']);
+  }
+
+  backToSelectToCompare() {
+    this.router.navigate(['/selectToCompare']);
+  }
+}

--- a/src/app/compare-radars/compare-radars.component.html
+++ b/src/app/compare-radars/compare-radars.component.html
@@ -1,31 +1,44 @@
 <div *ngIf="!radarsAreNullOrUndefined()">
 
-  <app-card-container [header]="title()">
+    <app-card-container [header]="title()">
 
-    <div class="card-body">
-      <app-radar-chart [radars]="parseRadarsToRadarChart()"></app-radar-chart>
+      <div *ngIf="axesInCommon().length !== 0; else incompatibleRadars">
 
-      <div *ngFor="let axis of axes()">
-        <hr>
-        <h5>{{ axis.title }}</h5>
-        <p>{{ axis.description }}</p>
+        <div class="card-body">
+          <app-radar-chart [radars]="parseRadarsToRadarChart()"></app-radar-chart>
 
-        <app-axis-bar-chart
-          [axis]="axis"
-          [values]="parseRadarsAxisValuesForAxisChart(axis)"
-          [radarTitles]="parseRadarTitlesToAxisChart()"
-          >
-        </app-axis-bar-chart>
+          <div *ngFor="let axis of axesInCommon()">
+            <hr>
+            <h5>{{ axis.title }}</h5>
+            <p>{{ axis.description }}</p>
 
-        <app-axis-table-values
-          [axis]="axis"
-          [values]="parseRadarsAxisValuesForAxisChart(axis)"
-          [radarTitles]="parseRadarTitlesToAxisChart()"
-        >
-        </app-axis-table-values>
+            <app-axis-bar-chart
+              [axis]="axis"
+              [values]="parseRadarsAxisValuesForAxisChart(axis)"
+              [radarTitles]="parseRadarTitlesToAxisChart()"
+              >
+            </app-axis-bar-chart>
+
+            <app-axis-table-values
+              [axis]="axis"
+              [values]="parseRadarsAxisValuesForAxisChart(axis)"
+              [radarTitles]="parseRadarTitlesToAxisChart()"
+            >
+            </app-axis-table-values>
+          </div>
+
+          <app-compare-radars-buttons></app-compare-radars-buttons>
+        </div>
+
       </div>
-    </div>
 
-  </app-card-container>
+      <ng-template #incompatibleRadars>
+        <div>
+          <h4 class="incompatible-title">Radares incompatibles</h4>
+          <app-compare-radars-buttons></app-compare-radars-buttons>
+        </div>
+      </ng-template>
+
+    </app-card-container>
 
 </div>

--- a/src/app/compare-radars/compare-radars.component.html
+++ b/src/app/compare-radars/compare-radars.component.html
@@ -1,27 +1,31 @@
-<app-card-container [header]="title()">
+<div *ngIf="!radarsAreNullOrUndefined()">
 
-  <div class="card-body">
-    <app-radar-chart [radars]="parseRadarsToRadarChart()"></app-radar-chart>
+  <app-card-container [header]="title()">
 
-    <div *ngFor="let axis of axes()">
-      <hr>
-      <h5>{{ axis.title }}</h5>
-      <p>{{ axis.description }}</p>
+    <div class="card-body">
+      <app-radar-chart [radars]="parseRadarsToRadarChart()"></app-radar-chart>
 
-      <app-axis-bar-chart
-        [axis]="axis"
-        [values]="parseRadarsAxisValuesForAxisChart(axis)"
-        [radarTitles]="parseRadarTitlesToAxisChart()"
+      <div *ngFor="let axis of axes()">
+        <hr>
+        <h5>{{ axis.title }}</h5>
+        <p>{{ axis.description }}</p>
+
+        <app-axis-bar-chart
+          [axis]="axis"
+          [values]="parseRadarsAxisValuesForAxisChart(axis)"
+          [radarTitles]="parseRadarTitlesToAxisChart()"
+          >
+        </app-axis-bar-chart>
+
+        <app-axis-table-values
+          [axis]="axis"
+          [values]="parseRadarsAxisValuesForAxisChart(axis)"
+          [radarTitles]="parseRadarTitlesToAxisChart()"
         >
-      </app-axis-bar-chart>
-
-      <app-axis-table-values
-        [axis]="axis"
-        [values]="parseRadarsAxisValuesForAxisChart(axis)"
-        [radarTitles]="parseRadarTitlesToAxisChart()"
-      >
-      </app-axis-table-values>
+        </app-axis-table-values>
+      </div>
     </div>
-  </div>
 
-</app-card-container>
+  </app-card-container>
+
+</div>

--- a/src/app/compare-radars/compare-radars.component.scss
+++ b/src/app/compare-radars/compare-radars.component.scss
@@ -1,0 +1,4 @@
+.incompatible-title {
+    text-align: center;
+    margin: 1em;
+}

--- a/src/app/compare-radars/compare-radars.component.ts
+++ b/src/app/compare-radars/compare-radars.component.ts
@@ -26,9 +26,15 @@ export class CompareRadarsComponent implements OnInit {
     return 'Comparación entre ' + this.firstRadar.title + ' y ' + this.secondRadar.title;
   }
 
-  axes() {
-    // TODO: debería ser solo las aristas que tienen en comun ambos radars
-    return this.firstRadar.axes;
+  axesInCommon() {
+    const axesInCommon = [];
+    this.firstRadar.axes.forEach(firstRadarAxis => {
+      if (this.secondRadar.axisBelongsToRadar(firstRadarAxis)) {
+        axesInCommon.push(firstRadarAxis);
+      }
+    });
+
+    return axesInCommon;
   }
 
   parseRadarsToRadarChart() {

--- a/src/app/compare-radars/compare-radars.component.ts
+++ b/src/app/compare-radars/compare-radars.component.ts
@@ -19,7 +19,7 @@ export class CompareRadarsComponent implements OnInit {
   ngOnInit() {
     this.compareRadarsService.firstRadar().subscribe(firstRadar => this.firstRadar = firstRadar);
     this.compareRadarsService.secondRadar().subscribe(secondRadar => this.secondRadar = secondRadar);
-    // TODO: si no hay radares debería llevar a la pagina de select-to-compare
+    this.redirectToSelectToCompareIfThereAreNotRadars();
   }
 
   title() {
@@ -41,5 +41,15 @@ export class CompareRadarsComponent implements OnInit {
 
   parseRadarTitlesToAxisChart() {
     return [this.firstRadar.title, this.secondRadar.title];
+  }
+
+  private redirectToSelectToCompareIfThereAreNotRadars() {
+    if (this.radarsAreNullOrUndefined()) {
+      this.router.navigateByUrl('/selectToCompare');
+    }
+  }
+
+  private radarsAreNullOrUndefined() {
+    return this.firstRadar === null || this.firstRadar === undefined || this.secondRadar === null || this.secondRadar === undefined;
   }
 }

--- a/src/mock-radars.ts
+++ b/src/mock-radars.ts
@@ -6,6 +6,16 @@ import { Vote } from './model/vote';
 const calidadTecnicaAxis = new Axis('Calidad técnica', 'La calidad técnica representa el eje...');
 const calidadHumanaAxis = new Axis('Calidad humana', 'La calidad humana representa el eje...');
 const ambienteLaboralAxis = new Axis('Ambiente laboral', 'El ambiente laboral representa el eje...');
+const buenosSueldosAxis = new Axis('Buenos Sueldos', 'Buenos sueldos representa al eje...');
+const saberSmalltalkAxis = new Axis('Saber SmallTalk', 'Saber SmallTalk representa al eje...');
+const saberHaskellAxis = new Axis('Saber Haskell', 'Saber Haskell representa al eje...');
+
+const DIFFERENT_AXES: Axis[] = [
+  buenosSueldosAxis,
+  saberSmalltalkAxis,
+  saberHaskellAxis,
+];
+
 export const AXES: Axis[] = [
   calidadTecnicaAxis,
   calidadHumanaAxis,
@@ -54,10 +64,13 @@ voteRadarTimes(radar2018, vote3, 5);
 voteRadarTimes(radar2018, vote4, 4);
 voteRadarTimes(radar2018, vote5, 1);
 
+const radar2015 = new Radar('Radar 2015', descripcionCorta, DIFFERENT_AXES, 4);
+
 export const RADARS: Radar[] = [
+  radar2015,
   radar2016,
   new Radar('Radar 2017', descripcionMedia, AXES, 2),
-  radar2018
+  radar2018,
 ];
 
 function voteRadarTimes(radar, vote, times) {

--- a/src/model/radar.ts
+++ b/src/model/radar.ts
@@ -55,6 +55,17 @@ export class Radar {
     return this.closed;
   }
 
+  axisBelongsToRadar(axis: Axis) {
+    let belongs = false;
+    this.axes.forEach(radarAxis => {
+      if (axis.title === radarAxis.title) {
+        belongs =  true;
+      }
+    });
+
+    return belongs;
+  }
+
   private validateAxisBelongsToRadar(axis) {
     if (this.axisBelongsToAxes(axis)) {
       throw new Error('El axis no pertenece al radar');


### PR DESCRIPTION
## Modificaciones con respecto al otro branch
* Corrijo el bug de que si se recarga la pagina los radares del servicio que utilizo para pasarlos son null. Ahora si son null redirige a `\selectToCompare`.
* Si ambos radares no tienen las mismas aristas (mismas aristas quiere decir que los titulos no son iguales) entonces muestra un mensaje de que los radares son incompatibles y te da la opcion del ir al index o a `\selectToCompare`
![image](https://user-images.githubusercontent.com/8728819/53140769-91c72b80-356c-11e9-8b87-5e9b46155b4d.png)
* Agrego botones iguales que los anteriores pero en la vista de comparacion de radares
![image](https://user-images.githubusercontent.com/8728819/53140847-c6d37e00-356c-11e9-9a6b-e13665086446.png)