### PR TITLE
Agrega toast component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,9 +2084,9 @@
       "integrity": "sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg=="
     },
     "@ng-bootstrap/ng-bootstrap": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-7.0.0.tgz",
-      "integrity": "sha512-SxUaptGWJmCxM0d2Zy1mx7K7p/YBwGZ69NmmBQVY4BE6p5av0hWrVmv9rzzfBz0rhxU7RPZLor2Jpaoq8Xyl4w==",
+      "version": "8.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-8.0.0-beta.1.tgz",
+      "integrity": "sha512-mCvCbfxr1oqenvWeNXMpIZk93NS6zPgb0UOX4N+hieRn8RFBfboRT7VKoeoNrpMFNrCimB04Z5yXJlBS1tx2xg==",
       "requires": {
         "tslib": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser": "^9.1.2",
     "@angular/platform-browser-dynamic": "^9.1.2",
     "@angular/router": "^9.1.2",
-    "@ng-bootstrap/ng-bootstrap": "^7.0.0",
+    "@ng-bootstrap/ng-bootstrap": "^8.0.0-beta.1",
     "@types/js-cookie": "^2.2.6",
     "bootstrap": "^4.5.0",
     "chart.js": "^2.9.3",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,6 +2,7 @@
 <div class="view-container-router">
   <div class="view-scrollable-container">
     <router-outlet></router-outlet>
+    <app-toasts></app-toasts>
   </div>
 </div>
 <app-footer></app-footer>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,64 +1,66 @@
-import { BrowserModule } from '@angular/platform-browser';
-import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { AppComponent } from './app.component';
-import { HeaderComponent } from './header/header.component';
-import { FooterComponent } from './footer/footer.component';
-import { AppRoutingModule } from './app-routing.module';
-import { RadarVoteComponent } from './radar-vote/radar-vote.component';
-import { AxisComponent } from './radar-vote/voting-radar/axis/axis.component';
-import { VotingRadarComponent } from './radar-vote/voting-radar/voting-radar.component';
-import { VotedRadarComponent } from './radar-vote/voted-radar/voted-radar.component';
-import { ResultsComponent } from './results/results.component';
-import { CardContainerComponent } from './card-container/card-container.component';
-import { IndexComponent } from './index/index.component';
-import { RadarRowComponent } from './index/radar-row/radar-row.component';
-import { RadarTemplateCardComponent } from './index/radar-template-card/radar-template-card.component';
-import { RadarTemplatePreViewComponent } from './index/radar-template-pre-view/radar-template-pre-view.component';
-import { RadarTemplateIndexDetailsComponent } from './index/radar-template-index-details/radar-template-index-details.component';
-import { ButtonWithIconComponent } from './commons/buttons/button-with-icon.component';
-import { HeaderFiltersComponent } from './index/header-filters/header-filters.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ToastrModule } from 'ngx-toastr';
-import { CreateRadarComponent } from './create-radar/create-radar.component';
-import { CreateRadarTemplateComponent } from './create-radar-template/create-radar-template.component';
-import { RadarTemplateFormComponent } from './create-radar-template/radar-template-form/radar-template-form.component';
-import { RadarTemplateAxisEvolutionComponent } from './radar-template/axis-evolution/radar-template-axis-evolution.component';
-import { RadarTemplateComponent } from './radar-template/radar-template.component';
-import { RadarTemplateAxisEvolutionLineChartComponent } from './radar-template/axis-evolution/charts/line-chart/radar-template-axis-evolution-line-chart.component';
-import { RadarTemplateAxisEvolutionDispersionChartComponent } from './radar-template/axis-evolution/charts/dispersion-chart/radar-template-axis-evolution-dispersion-chart.component';
-import { RadarFormComponent } from './create-radar/radar-form/radar-form.component';
-import { AxesFormComponent } from './create-radar/axes-form/axes-form.component';
-import { TokenComponent } from './token/token.component';
-import { ErrorComponent } from './error/error.component';
+import {BrowserModule} from '@angular/platform-browser';
+import {HTTP_INTERCEPTORS, HttpClientModule} from '@angular/common/http';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {AppComponent} from './app.component';
+import {HeaderComponent} from './header/header.component';
+import {FooterComponent} from './footer/footer.component';
+import {AppRoutingModule} from './app-routing.module';
+import {RadarVoteComponent} from './radar-vote/radar-vote.component';
+import {AxisComponent} from './radar-vote/voting-radar/axis/axis.component';
+import {VotingRadarComponent} from './radar-vote/voting-radar/voting-radar.component';
+import {VotedRadarComponent} from './radar-vote/voted-radar/voted-radar.component';
+import {ResultsComponent} from './results/results.component';
+import {CardContainerComponent} from './card-container/card-container.component';
+import {IndexComponent} from './index/index.component';
+import {RadarRowComponent} from './index/radar-row/radar-row.component';
+import {RadarTemplateCardComponent} from './index/radar-template-card/radar-template-card.component';
+import {RadarTemplatePreViewComponent} from './index/radar-template-pre-view/radar-template-pre-view.component';
+import {RadarTemplateIndexDetailsComponent} from './index/radar-template-index-details/radar-template-index-details.component';
+import {ButtonWithIconComponent} from './commons/buttons/button-with-icon.component';
+import {HeaderFiltersComponent} from './index/header-filters/header-filters.component';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {ToastrModule} from 'ngx-toastr';
+import {CreateRadarComponent} from './create-radar/create-radar.component';
+import {CreateRadarTemplateComponent} from './create-radar-template/create-radar-template.component';
+import {RadarTemplateFormComponent} from './create-radar-template/radar-template-form/radar-template-form.component';
+import {RadarTemplateAxisEvolutionComponent} from './radar-template/axis-evolution/radar-template-axis-evolution.component';
+import {RadarTemplateComponent} from './radar-template/radar-template.component';
+import {RadarTemplateAxisEvolutionLineChartComponent} from './radar-template/axis-evolution/charts/line-chart/radar-template-axis-evolution-line-chart.component';
+import {RadarTemplateAxisEvolutionDispersionChartComponent} from './radar-template/axis-evolution/charts/dispersion-chart/radar-template-axis-evolution-dispersion-chart.component';
+import {RadarFormComponent} from './create-radar/radar-form/radar-form.component';
+import {AxesFormComponent} from './create-radar/axes-form/axes-form.component';
+import {TokenComponent} from './token/token.component';
+import {ErrorComponent} from './error/error.component';
 import {TokenService} from '../services/token.service';
-import { SelectToCompareComponent } from './select-to-compare/select-to-compare.component';
-import { CompareRadarsComponent } from './compare-radars/compare-radars.component';
-import { AxisBarChartComponent } from './chart-components/axis-bar-chart/axis-bar-chart.component';
-import { AxisTableValuesComponent } from './chart-components/axis-table-values/axis-table-values.component';
-import { RadarChartComponent } from './chart-components/radar-chart/radar-chart.component';
-import { CompareRadarsButtonsComponent } from './compare-radars/compare-radars-buttons/compare-radars-buttons.component';
-import { HttpRadarService } from 'src/services/http-radar.service';
-import { HttpRadarTemplateService } from 'src/services/http-radarTemplate.service';
-import { SignInComponent } from './sign-in/sign-in.component';
-import { HttpConfigInterceptor } from 'src/interceptor/httpconfig.interceptor';
-import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
-import { RadarTemplateVisualizerComponent } from './chart-components/template-chart/template-visualizer.component';
+import {SelectToCompareComponent} from './select-to-compare/select-to-compare.component';
+import {CompareRadarsComponent} from './compare-radars/compare-radars.component';
+import {AxisBarChartComponent} from './chart-components/axis-bar-chart/axis-bar-chart.component';
+import {AxisTableValuesComponent} from './chart-components/axis-table-values/axis-table-values.component';
+import {RadarChartComponent} from './chart-components/radar-chart/radar-chart.component';
+import {CompareRadarsButtonsComponent} from './compare-radars/compare-radars-buttons/compare-radars-buttons.component';
+import {HttpRadarService} from 'src/services/http-radar.service';
+import {HttpRadarTemplateService} from 'src/services/http-radarTemplate.service';
+import {SignInComponent} from './sign-in/sign-in.component';
+import {HttpConfigInterceptor} from 'src/interceptor/httpconfig.interceptor';
+import {PageNotFoundComponent} from './page-not-found/page-not-found.component';
+import {RadarTemplateVisualizerComponent} from './chart-components/template-chart/template-visualizer.component';
 import {FitTextDirective} from './commons/directives/fittext.directive';
 import {NgPipesModule} from 'ngx-pipes';
-import {HttpRadarTemplateContainerService} from "../services/http-radarTemplateContainer.service";
-import {RadarTemplateContainerCardComponent} from "./index/radar-template-container-card/radar-template-container-card.component";
-import {RadarTemplateContainerComponent} from "./radar-template/container/radar-template-container.component";
+import {HttpRadarTemplateContainerService} from '../services/http-radarTemplateContainer.service';
+import {RadarTemplateContainerCardComponent} from './index/radar-template-container-card/radar-template-container-card.component';
+import {RadarTemplateContainerComponent} from './radar-template/container/radar-template-container.component';
 import {CallToActionHeaderButton} from './index/call-to-actions-buttons/call-to-action-header-button';
 import {IndexHeaderComponent} from './index/index-header/index-header-component';
-import { VotingCodeComponent } from './voting-code/voting-code.component';
-import { RadarTemplateContainerCreateCardComponent } from './index/radar-template-container-create-card/radar-template-container-create-card.component'
-import { WizzardArrows } from './radar-vote/wizzard-arrows/wizzard-arrows.component';
-import {HttpVotingService} from "../services/http-voting.service";
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { CarouselModule } from 'ngx-bootstrap/carousel';
-import { NgScrollbarModule } from 'ngx-scrollbar';
+import {VotingCodeComponent} from './voting-code/voting-code.component';
+import {RadarTemplateContainerCreateCardComponent} from './index/radar-template-container-create-card/radar-template-container-create-card.component';
+import {WizzardArrows} from './radar-vote/wizzard-arrows/wizzard-arrows.component';
+import {HttpVotingService} from '../services/http-voting.service';
+import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
+import {CarouselModule} from 'ngx-bootstrap/carousel';
+import {NgScrollbarModule} from 'ngx-scrollbar';
+import {ToastService} from '../services/toast.service';
+import {ToastComponent} from './commons/toasts/toast.component';
 
 @NgModule({
   declarations: [
@@ -106,7 +108,8 @@ import { NgScrollbarModule } from 'ngx-scrollbar';
     CallToActionHeaderButton,
     VotingCodeComponent,
     IndexHeaderComponent,
-    WizzardArrows
+    WizzardArrows,
+    ToastComponent,
   ],
   imports: [
     BrowserModule,
@@ -130,7 +133,8 @@ import { NgScrollbarModule } from 'ngx-scrollbar';
     {provide: 'RadarTemplateContainerService', useClass: HttpRadarTemplateContainerService},
     {provide: 'VotingService', useClass: HttpVotingService},
     {provide: HTTP_INTERCEPTORS, useClass: HttpConfigInterceptor, multi: true},
-    TokenService
+    TokenService,
+    ToastService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/commons/toasts/toast.component.html
+++ b/src/app/commons/toasts/toast.component.html
@@ -1,0 +1,14 @@
+<ngb-toast
+  *ngFor="let toast of toastService.toasts"
+  [header]="toast.headertext"
+  [class]="toast.classname"
+  [autohide]="toast.autohide"
+  [delay]="toast.delay || 5000"
+  (hide)="toastService.remove(toast)"
+>
+  <ng-template [ngIf]="isTemplate(toast)" [ngIfElse]="text">
+    <ng-template [ngTemplateOutlet]="toast.textOrTpl"></ng-template>
+  </ng-template>
+
+  <ng-template #text>{{ toast.textOrTpl }}</ng-template>
+</ngb-toast>

--- a/src/app/commons/toasts/toast.component.html
+++ b/src/app/commons/toasts/toast.component.html
@@ -6,9 +6,11 @@
   [delay]="toast.delay || 5000"
   (hide)="toastService.remove(toast)"
 >
-  <ng-template [ngIf]="isTemplate(toast)" [ngIfElse]="text">
-    <ng-template [ngTemplateOutlet]="toast.textOrTpl"></ng-template>
-  </ng-template>
+  <div class="toast-content" >
+    <span> {{ toast.text }} </span>
+    <div class="toast-close-icon" (click)="onCloseClick(toast)">
+      <i class=" fas fa-times" ></i>
+    </div>
+  </div>
 
-  <ng-template #text>{{ toast.textOrTpl }}</ng-template>
 </ngb-toast>

--- a/src/app/commons/toasts/toast.component.scss
+++ b/src/app/commons/toasts/toast.component.scss
@@ -1,0 +1,17 @@
+.toast-content {
+  min-width: 15em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  overflow-wrap: break-word;
+
+  span {
+    width: 70%;
+    overflow-wrap: break-word;
+  }
+
+  .toast-close-icon {
+    margin: 0 1em;
+    cursor: pointer;
+  }
+}

--- a/src/app/commons/toasts/toast.component.ts
+++ b/src/app/commons/toasts/toast.component.ts
@@ -4,24 +4,10 @@ import { ToastService } from 'src/services/toast.service';
 
 @Component({
   selector: 'app-toasts',
-  template: `
-    <ngb-toast
-      *ngFor="let toast of toastService.toasts"
-      [header]="toast.headertext"
-      [class]="toast.classname"
-      [autohide]="toast.autohide"
-      [delay]="toast.delay || 5000"
-      (hide)="toastService.remove(toast)"
-    >
-      <ng-template [ngIf]="isTemplate(toast)" [ngIfElse]="text">
-        <ng-template [ngTemplateOutlet]="toast.textOrTpl"></ng-template>
-      </ng-template>
-
-      <ng-template #text>{{ toast.textOrTpl }}</ng-template>
-    </ngb-toast>
-  `,
+  templateUrl: './toast.component.html',
   host: {'[class.ngb-toasts]': 'true'}
 })
+
 export class ToastComponent {
   constructor(public toastService: ToastService) {}
 

--- a/src/app/commons/toasts/toast.component.ts
+++ b/src/app/commons/toasts/toast.component.ts
@@ -1,0 +1,29 @@
+import {Component, TemplateRef} from '@angular/core';
+import { ToastService } from 'src/services/toast.service';
+
+
+@Component({
+  selector: 'app-toasts',
+  template: `
+    <ngb-toast
+      *ngFor="let toast of toastService.toasts"
+      [header]="toast.headertext"
+      [class]="toast.classname"
+      [autohide]="toast.autohide"
+      [delay]="toast.delay || 5000"
+      (hide)="toastService.remove(toast)"
+    >
+      <ng-template [ngIf]="isTemplate(toast)" [ngIfElse]="text">
+        <ng-template [ngTemplateOutlet]="toast.textOrTpl"></ng-template>
+      </ng-template>
+
+      <ng-template #text>{{ toast.textOrTpl }}</ng-template>
+    </ngb-toast>
+  `,
+  host: {'[class.ngb-toasts]': 'true'}
+})
+export class ToastComponent {
+  constructor(public toastService: ToastService) {}
+
+  isTemplate(toast) { return toast.textOrTpl instanceof TemplateRef; }
+}

--- a/src/app/commons/toasts/toast.component.ts
+++ b/src/app/commons/toasts/toast.component.ts
@@ -5,11 +5,16 @@ import { ToastService } from 'src/services/toast.service';
 @Component({
   selector: 'app-toasts',
   templateUrl: './toast.component.html',
-  host: {'[class.ngb-toasts]': 'true'}
+  styleUrls: ['./toast.component.scss'],
+  host: {'[class.ngb-toasts]': 'true'},
 })
 
 export class ToastComponent {
   constructor(public toastService: ToastService) {}
 
   isTemplate(toast) { return toast.textOrTpl instanceof TemplateRef; }
+
+  onCloseClick(toast) {
+    this.toastService.remove(toast);
+  }
 }

--- a/src/app/radar-template/container/radar-template-container.component.html
+++ b/src/app/radar-template/container/radar-template-container.component.html
@@ -100,4 +100,5 @@
       [radarTemplate]="selectedRadarTemplate"
     ></app-radar-template>
   </div>
+  <app-toasts></app-toasts>
 </div>

--- a/src/app/radar-template/container/radar-template-container.component.html
+++ b/src/app/radar-template/container/radar-template-container.component.html
@@ -100,5 +100,4 @@
       [radarTemplate]="selectedRadarTemplate"
     ></app-radar-template>
   </div>
-  <app-toasts></app-toasts>
 </div>

--- a/src/app/radar-template/container/radar-template-container.component.ts
+++ b/src/app/radar-template/container/radar-template-container.component.ts
@@ -68,7 +68,7 @@ export class RadarTemplateContainerComponent implements OnInit {
 
       this.setSelectedRadarTemplate(this.radarTemplateContainer.radar_templates[this.selectedRadarTemplateIndex]);
       this.showCreateVotingForm = false;
-      this.toastService.showSuccess('Se pudo crear el voting, la vida es bella');
+      this.toastService.showSuccess('Votación creada con éxito');
     });
   };
 

--- a/src/app/radar-template/container/radar-template-container.component.ts
+++ b/src/app/radar-template/container/radar-template-container.component.ts
@@ -1,10 +1,10 @@
-import {Component, OnInit, Input, Inject, OnChanges} from '@angular/core';
-import {ActivatedRoute} from "@angular/router";
-import {Router} from "@angular/router";
-import {RadarTemplateContainer} from "../../../model/radarTemplateContainer";
-import {RadarTemplateContainerService} from "../../../services/radarTemplateContainer.service";
-import {VotingService} from "../../../services/voting.service";
-import { NgbDateStruct, NgbCalendar } from '@ng-bootstrap/ng-bootstrap';
+import {Component, Inject, Input, OnInit} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
+import {RadarTemplateContainer} from '../../../model/radarTemplateContainer';
+import {RadarTemplateContainerService} from '../../../services/radarTemplateContainer.service';
+import {VotingService} from '../../../services/voting.service';
+import {NgbCalendar, NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
+import {ToastService} from '../../../services/toast.service';
 
 @Component({
   selector: 'app-radar-template-container',
@@ -24,9 +24,10 @@ export class RadarTemplateContainerComponent implements OnInit {
 
   constructor(@Inject('RadarTemplateContainerService') private radarTemplateContainerService: RadarTemplateContainerService,
               @Inject('VotingService') private votingService: VotingService,
+              private toastService: ToastService,
               private calendar: NgbCalendar,
               private route: ActivatedRoute,  private router: Router) {
-    this.id = this.route.snapshot.paramMap.get("id")
+    this.id = this.route.snapshot.paramMap.get('id');
   }
 
   ngOnInit() {
@@ -52,7 +53,7 @@ export class RadarTemplateContainerComponent implements OnInit {
     return !!this.votingCode;
   }
 
-  canCreateVoting(){
+  canCreateVoting() {
     return !this.hasVotingCode() && !!this.calendarData;
   }
 
@@ -67,14 +68,15 @@ export class RadarTemplateContainerComponent implements OnInit {
 
       this.setSelectedRadarTemplate(this.radarTemplateContainer.radar_templates[this.selectedRadarTemplateIndex]);
       this.showCreateVotingForm = false;
-    })
-  }
+      this.toastService.showSuccess('Se pudo crear el voting, la vida es bella');
+    });
+  };
 
   getSelectedDate () {
-    return this.calendarData.year + "-" + this.calendarData.month + "-" + this.calendarData.day;
+    return this.calendarData.year + '-' + this.calendarData.month + '-' + this.calendarData.day;
   }
 
-  isSelected(radarTemplate){
+  isSelected(radarTemplate) {
     return this.selectedRadarTemplate.id === radarTemplate.id;
   }
 
@@ -82,21 +84,21 @@ export class RadarTemplateContainerComponent implements OnInit {
     return this.radarTemplateContainer.radar_templates;
   }
 
-  onRadarTemplateCardClick(radarTemplate, index){
+  onRadarTemplateCardClick(radarTemplate, index) {
     this.setSelectedRadarTemplate(radarTemplate);
     this.selectedRadarTemplateIndex = index;
   }
 
-  setSelectedRadarTemplate(radarTemplate){
-    this.selectedRadarTemplate = radarTemplate
+  setSelectedRadarTemplate(radarTemplate) {
+    this.selectedRadarTemplate = radarTemplate;
   }
 
-  addRadar(){
-    console.error("Aun no se implemento la creacion de radares")
+  addRadar() {
+    console.error('Aun no se implemento la creacion de radares');
   }
 
-  isContainerEmpty(){
-    return this.radarTemplates().length==0
+  isContainerEmpty() {
+    return this.radarTemplates().length === 0;
   }
 
 }

--- a/src/services/toast.service.ts
+++ b/src/services/toast.service.ts
@@ -7,21 +7,19 @@ export class ToastService {
     this.toasts = [];
   }
 
-  showSuccess(textOrTpl: string) {
-    this.show(textOrTpl, {
+  showSuccess(text: string) {
+    this.show(text, {
       classname: 'bg-success text-light',
-      delay: 2000 ,
+      delay: 5000 ,
       autohide: true,
-      headertext: 'Operación exitosa'
     });
   }
 
-  showError(textOrTpl: string) {
-    this.show(textOrTpl, {
+  showError(text: string) {
+    this.show(text, {
       classname: 'bg-danger text-light',
-      delay: 2000 ,
+      delay: 5000 ,
       autohide: true,
-      headertext: 'Hubo un error en la operación'
     });
   }
 
@@ -29,7 +27,7 @@ export class ToastService {
     this.toasts = this.toasts.filter(t => t !== toast);
   }
 
-  private show(textOrTpl: string | TemplateRef<any>, options: any = {}) {
-    this.toasts.push({ textOrTpl, ...options });
+  private show(text: string, options: any = {}) {
+    this.toasts.push({ text, ...options });
   }
 }

--- a/src/services/toast.service.ts
+++ b/src/services/toast.service.ts
@@ -21,7 +21,7 @@ export class ToastService {
       classname: 'bg-danger text-light',
       delay: 2000 ,
       autohide: true,
-      headertext: 'Error!!!'
+      headertext: 'Hubo un error en la operación'
     });
   }
 

--- a/src/services/toast.service.ts
+++ b/src/services/toast.service.ts
@@ -1,0 +1,35 @@
+import {Injectable, TemplateRef} from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  toasts: any[];
+  constructor() {
+    this.toasts = [];
+  }
+
+  showSuccess(textOrTpl: string) {
+    this.show(textOrTpl, {
+      classname: 'bg-success text-light',
+      delay: 2000 ,
+      autohide: true,
+      headertext: 'Toast Header'
+    });
+  }
+
+  showError(textOrTpl: string) {
+    this.show(textOrTpl, {
+      classname: 'bg-danger text-light',
+      delay: 2000 ,
+      autohide: true,
+      headertext: 'Error!!!'
+    });
+  }
+
+  remove(toast) {
+    this.toasts = this.toasts.filter(t => t !== toast);
+  }
+
+  private show(textOrTpl: string | TemplateRef<any>, options: any = {}) {
+    this.toasts.push({ textOrTpl, ...options });
+  }
+}

--- a/src/services/toast.service.ts
+++ b/src/services/toast.service.ts
@@ -12,7 +12,7 @@ export class ToastService {
       classname: 'bg-success text-light',
       delay: 2000 ,
       autohide: true,
-      headertext: 'Toast Header'
+      headertext: 'Operación exitosa'
     });
   }
 

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -1,9 +1,8 @@
-import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import * as Cookies from 'js-cookie'
-import { env } from 'process';
-import { environment } from 'src/environments/environment';
-import { User } from 'src/model/user';
+import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import * as Cookies from 'js-cookie';
+import {environment} from 'src/environments/environment';
+import {User} from 'src/model/user';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
Este pr se encarga de agregar un toast service y un toast component genéricos para permitir toast notifications. Primera iteración con estilos y mensajes a redefinir. Hay un caso de prueba de un toast success en radar template container. [Trello](https://trello.com/c/egk7X47n/166-mecanismo-de-toast-notifications)