### PR TITLE
Fix de mensaje de votación inexistente en pantalla de votación de radar

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,17 +10,18 @@ import { SelectToCompareComponent } from './select-to-compare/select-to-compare.
 import { CompareRadarsComponent } from './compare-radars/compare-radars.component';
 import { SignInComponent } from './sign-in/sign-in.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
-import {CreateRadarTemplateComponent} from "./create-radar-template/create-radar-template.component";
-import {RadarTemplateContainerComponent} from "./radar-template/container/radar-template-container.component";
+import {CreateRadarTemplateComponent} from './create-radar-template/create-radar-template.component';
+import {RadarTemplateContainerComponent} from './radar-template/container/radar-template-container.component';
 import { VotingCodeComponent } from './voting-code/voting-code.component';
 import { pages } from 'src/services/currentPage.service';
+import {VotingResolver} from './resolvers/voting-resolver';
 
 export const routes: Routes = [
-  { path: '', pathMatch: 'full', component: SignInComponent, data:{page:pages.LOGIN}},
-  { path: 'radarTemplates', component: IndexComponent, data:{page:pages.INDEX} },
+  { path: '', pathMatch: 'full', component: SignInComponent, data: {page: pages.LOGIN}},
+  { path: 'radarTemplates', component: IndexComponent, data: {page: pages.INDEX} },
   { path: 'token/:token', component: TokenComponent },
   { path: 'error', component: ErrorComponent },
-  { path: 'vote/:code', component: RadarVoteComponent },
+  { path: 'vote/:code', component: RadarVoteComponent, resolve: {voting: VotingResolver} },
   { path: 'results/:code', component: RadarTemplateContainerComponent},
   { path: 'radar/:id/results', component: ResultsComponent },
   { path: 'radar/create', component: CreateRadarComponent },
@@ -35,6 +36,7 @@ export const routes: Routes = [
 
 @NgModule({
   imports: [ RouterModule.forRoot(routes) ],
-  exports: [ RouterModule ]
+  exports: [ RouterModule ],
+  providers: [ VotingResolver ]
 })
 export class AppRoutingModule {}

--- a/src/app/radar-vote/radar-vote.component.html
+++ b/src/app/radar-vote/radar-vote.component.html
@@ -5,9 +5,9 @@
       <div class="wizzard-steps">
         <wizzard-arrows [currentStep]="currentStep" [radarTemplates]="votableRadarTemplates(radarContainer)"></wizzard-arrows>
       </div>
-      
+
       <div *ngIf="!hasVotationEnded(); else elseVotedBlock" class="votation-container">
-          <app-voting-radar 
+          <app-voting-radar
             [radarTemplate]="currentStepRadarTemplate()"
             [hasNextStep]="hasNextStep()"
             (voted)="templateVoted()" >
@@ -30,7 +30,7 @@
   <div  class="component-centerer">
   <div class="radar-container">
     <div class="votation-container">
-        <h3>No existe la votacion</h3>
+        <h3>No existe la votación</h3>
     </div>
   </div>
 </div>

--- a/src/app/radar-vote/radar-vote.component.ts
+++ b/src/app/radar-vote/radar-vote.component.ts
@@ -1,35 +1,31 @@
-import { Component, Inject, OnInit } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
-import { Axis } from "../../model/axis";
-import { RadarTemplate } from "src/model/radarTemplate";
-import { RadarTemplateContainer } from "src/model/radarTemplateContainer";
-import { VotingService } from "src/services/voting.service";
-import { Voting } from "src/model/voting";
-import { DOCUMENT } from '@angular/common';
+import {Component, Inject, OnInit} from '@angular/core';
+import {ActivatedRoute, Data} from '@angular/router';
+import {Axis} from '../../model/axis';
+import {RadarTemplate} from 'src/model/radarTemplate';
+import {RadarTemplateContainer} from 'src/model/radarTemplateContainer';
+import {Voting} from 'src/model/voting';
+import {DOCUMENT} from '@angular/common';
 
 @Component({
-  selector: "app-radar-vote",
-  templateUrl: "./radar-vote.component.html",
-  styleUrls: ["./radar-vote.component.scss"],
+  selector: 'app-radar-vote',
+  templateUrl: './radar-vote.component.html',
+  styleUrls: ['./radar-vote.component.scss'],
 })
 export class RadarVoteComponent implements OnInit {
-  radarContainer: RadarTemplateContainer;
-  voting : Voting
-  currentStep: number = 0;
+  radarContainer: RadarTemplateContainer = null;
+  voting: Voting = null;
+  currentStep = 0;
 
   constructor(
-    @Inject("VotingService")
-    private votingService: VotingService,
     private route: ActivatedRoute,
     @Inject(DOCUMENT) private document: Document
   ) {}
 
   ngOnInit() {
-    const code: string = this.route.snapshot.paramMap.get("code");
-    this.votingService.retrieveFromHistoryOrGet(code).subscribe((voting : Voting) =>{
-      this.voting = voting
-      this.radarContainer = voting.radar_template_container;
-    })
+    this.route.data.subscribe( (data: Data) => {
+      this.voting = data['voting'];
+      this.radarContainer = data.voting.radar_template_container;
+    });
   }
 
   canContainerBeVoted(container: RadarTemplateContainer): boolean {
@@ -56,8 +52,8 @@ export class RadarVoteComponent implements OnInit {
       .some((radar: RadarTemplate) => radar.active);
   }
 
-  hasVotationEnded() : boolean{
-    return this.votableRadarTemplates(this.radarContainer).length === this.currentStep
+  hasVotationEnded(): boolean {
+    return this.votableRadarTemplates(this.radarContainer).length === this.currentStep;
   }
 
   title() {
@@ -66,7 +62,7 @@ export class RadarVoteComponent implements OnInit {
 
   templateVoted() {
     this.currentStep++;
-    this.document.getElementsByClassName("view-scrollable-container")[0].scrollTop = 0
+    this.document.getElementsByClassName('view-scrollable-container')[0].scrollTop = 0;
   }
 
   votableRadarTemplates(container: RadarTemplateContainer) {

--- a/src/app/resolvers/voting-resolver.ts
+++ b/src/app/resolvers/voting-resolver.ts
@@ -1,0 +1,14 @@
+import {Inject, Injectable} from '@angular/core';
+import {ActivatedRouteSnapshot, Resolve, RouterStateSnapshot} from '@angular/router';
+import {Voting} from '../../model/voting';
+import {Observable} from 'rxjs';
+import {VotingService} from '../../services/voting.service';
+
+@Injectable()
+export class VotingResolver implements Resolve<Voting> {
+  constructor(@Inject('VotingService') private service: VotingService) {}
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Voting> {
+    return this.service.retrieveFromHistoryOrGet(route.paramMap.get('code'));
+  }
+}

--- a/src/services/voting.service.ts
+++ b/src/services/voting.service.ts
@@ -4,6 +4,6 @@ import {Voting} from '../model/voting';
 export interface VotingService {
   create(radarTemplateContainerId: string, name: string, ends_at: string): any;
   get(code: string): any;
-  retrieveFromHistoryOrGet(code: string) : Observable<Voting>;
+  retrieveFromHistoryOrGet(code: string): Observable<Voting>;
   close(radarTemplateContainerId: string): Observable<Voting>;
 }


### PR DESCRIPTION
Fix de mensaje "No existe la votación" al primer instante de ir a la página de votación. 
Problema: se llamaba al voting service desde ngOnInit del componente radar-vote. Se intenta renderizar el componente antes de este hook, al no tener la data necesaria en la ventana de tiempo del fetch, muestra el mensaje de error asociado a no tener esa data. 
Fix: agregar resolver de voting service para fetchear data de un voting antes de renderizar el componente radar-vote. El fetch se hace por fuera del componente.